### PR TITLE
Testy oraz JWT

### DIFF
--- a/JWT/jwt-signature-apis-challenges/app.js
+++ b/JWT/jwt-signature-apis-challenges/app.js
@@ -31,7 +31,7 @@ app.post('/jwt/none', (req, res) => { //None endpoint
     } else if (jwt_b64_dec.header.alg == 'none') {
       secret_key = '';
     }
-    JWT.verify(jwt_token, secret_key, { algorithms: ['none', 'HS256'], complete: true, audience: 'https://127.0.0.1/jwt/none' }, (err, decoded_token) => {
+    JWT.verify(jwt_token, secret_key, { algorithms: [ 'HS256'], complete: true, audience: 'https://127.0.0.1/jwt/none' }, (err, decoded_token) => {
       if (err) {
         res.status(400).json(err);
       } else {

--- a/Python/Flask_Book_Library/Dockerfile
+++ b/Python/Flask_Book_Library/Dockerfile
@@ -11,6 +11,9 @@ ENV PASSWORD=1qaz@WSX
 # Instalujemy zależności
 RUN pip install --no-cache-dir -r requirements.txt
 
+# Przeprowadzanie testów
+RUN python3 -m pytest
+
 # Ustawiamy zmienną środowiskową, aby Flask wiedział, jak uruchomić aplikację
 ENV FLASK_APP=app.py
 ENV FLASK_RUN_HOST=0.0.0.0

--- a/Python/Flask_Book_Library/requirements.txt
+++ b/Python/Flask_Book_Library/requirements.txt
@@ -15,3 +15,4 @@ SQLAlchemy==2.0.21
 typing_extensions==4.8.0
 Werkzeug==2.3.7
 WTForms==3.0.1
+pytest==7.4.3

--- a/Python/Flask_Book_Library/tests/test_customer_correct_data.py
+++ b/Python/Flask_Book_Library/tests/test_customer_correct_data.py
@@ -1,0 +1,113 @@
+import pytest
+from project.customers.models import Customer
+
+def create_customer(name: str = "John Brown",
+                    city: str = "New York",
+                    age: int = 33,
+                    pesel: str = 11*"9",
+                    street: str = "Best Brooker",
+                    app: str = "17b") -> Customer:
+    Customer(name, city, age, pesel, street, app)
+
+# Correct data input
+def test_full_dummy_correct_data():
+    create_customer()
+    
+@pytest.mark.parametrize("correct_name", 
+    [
+        "Adam Switch", 
+        "Mike Brown", 
+        "Judy Hopps", 
+        "Nick Wilde"
+    ])
+def test_correct_name(correct_name):
+    create_customer(name = correct_name)
+    
+@pytest.mark.parametrize("correct_city", 
+    [
+        "Berlin", 
+        "Stockholm", 
+        "Helsinki" 
+    ])
+def test_correct_city(correct_city):
+    create_customer(city = correct_city)
+    
+@pytest.mark.parametrize("correct_age", 
+    [
+        17, 
+        88, 
+        54 
+    ])
+def test_correct_age(correct_age):
+    create_customer(age = correct_age)
+
+@pytest.mark.parametrize("correct_pesel", 
+    [
+        11*"2", 
+        "12345678910", 
+        "78787878787" 
+    ])
+def test_correct_pesel(correct_pesel):
+    create_customer(pesel = correct_pesel)
+    
+@pytest.mark.parametrize("correct_street", 
+    [
+        "Ul. Nowowiejska", 
+        "Saint Marias Street", 
+        "Wunderburger Straßen" 
+    ])
+def test_correct_pesel(correct_street):
+    create_customer(street = correct_street)
+    
+@pytest.mark.parametrize("correct_app", 
+    [
+        "34/17", 
+        "3", 
+        "37 1/2",
+        "190b"
+    ])
+def test_correct_app(correct_app):
+    create_customer(app=correct_app)
+
+#Edge cases data input
+@pytest.mark.parametrize("edge_name", 
+    [
+        "a",
+        "b"*64,
+    ])
+def test_edge_name(edge_name):
+    create_customer(name = edge_name)
+    
+@pytest.mark.parametrize("edge_city", 
+    [
+        "a",
+        "b"*64,
+    ])
+def test_edge_city(edge_city):
+    create_customer(city = edge_city)
+    
+@pytest.mark.parametrize("edge_age", 
+    [
+        0,
+        1,
+        9182471774
+    ])
+def test_edge_age(edge_age):
+    create_customer(age = edge_age)
+
+    
+@pytest.mark.parametrize("edge_street", 
+    [
+        "a",
+        "b"*128,
+    ])
+def test_edge_pesel(edge_street):
+    create_customer(street = edge_street)
+    
+@pytest.mark.parametrize("edge_app", 
+    [
+        "1",
+        "9"*10,
+    ])
+def test_edge_app(edge_app):
+    create_customer(app=edge_app)

--- a/Python/Flask_Book_Library/tests/test_customer_extreme_data.py
+++ b/Python/Flask_Book_Library/tests/test_customer_extreme_data.py
@@ -1,0 +1,60 @@
+import pytest
+from project.customers.models import Customer
+
+def create_customer(name: str = "John Brown",
+                    city: str = "New York",
+                    age: int = 33,
+                    pesel: str = 11*"9",
+                    street: str = "Best Brooker",
+                    app: str = "17b") -> Customer:
+    Customer(name, city, age, pesel, street, app)
+
+numeric_extreme_values = [
+    -(10**4),
+    -(10**6),
+    -(10**8),
+    10**4,
+    10**6,
+    10**8,
+    2**15,  # Maximum for smallint in SQL Server Smallint is 2**15-1
+    2**16,  # Maximum for unsigned SmallInt in MySQL unsigned is 2**16-1 
+    2**24,  # Maximum for unsigned for MediumInt in MySQL is 2*24-1
+    2**31,  # Maximum for integer in SQL Server is 2**31-1 
+    2**32,  # Maximum for unsigned Integer in MySQL is 2**32-1 
+]
+
+string_extreme_values = [
+    "A" * 10**4,
+    "A" * (2**16), # The MySQL server VARCHAR has a max length of 2^16-1 
+    "A" * (2**32), # The SQL server VARCHAR has a max length of 2^32-1    
+]
+
+@pytest.mark.parametrize("extreme_data", string_extreme_values)
+def test_extreme_name(extreme_data):
+    with pytest.raises(Exception):
+        create_customer(name = extreme_data)
+
+@pytest.mark.parametrize("extreme_data", numeric_extreme_values)
+def test_extreme_age(extreme_data):
+    with pytest.raises(Exception):
+        create_customer(age = extreme_data)
+
+@pytest.mark.parametrize("extreme_data", string_extreme_values)
+def test_extreme_city(extreme_data):
+    with pytest.raises(Exception):
+        create_customer(city = extreme_data)
+
+@pytest.mark.parametrize("extreme_data", string_extreme_values)
+def test_extreme_pesel(extreme_data):
+    with pytest.raises(Exception):
+        create_customer(pesel = extreme_data)
+
+@pytest.mark.parametrize("extreme_data", string_extreme_values)
+def test_extreme_street(extreme_data):
+    with pytest.raises(Exception):
+        create_customer(street = extreme_data)
+
+@pytest.mark.parametrize("extreme_data", string_extreme_values)
+def test_extreme_app(extreme_data):
+    with pytest.raises(Exception):
+        create_customer(app = extreme_data)

--- a/Python/Flask_Book_Library/tests/test_customer_incorrect_data.py
+++ b/Python/Flask_Book_Library/tests/test_customer_incorrect_data.py
@@ -1,0 +1,125 @@
+import pytest
+from project.customers.models import Customer
+
+uniform_incorrect_string_data = [
+    None,
+    "!@#$%^&*(){/}[]?><,./;';\"\\",
+    "############",
+    " ",
+    "              "
+    "\t",
+    "\n",
+    1234,
+    -5,
+    0,
+    3.131,
+    [],
+    {},
+    ()
+]
+
+def create_customer(name: str = "John Brown",
+                    city: str = "New York",
+                    age: int = 33,
+                    pesel: str = 11*"9",
+                    street: str = "Best Brooker",
+                    app: str = "17b") -> Customer:
+    Customer(name, city, age, pesel, street, app)
+
+# Uniform incorrect data input
+@pytest.mark.parametrize("incorrect_string_name", uniform_incorrect_string_data)
+def test_incorrect_uniform_name(incorrect_string_name):
+    with pytest.raises(Exception):
+        create_customer(name = incorrect_string_name)
+
+@pytest.mark.parametrize("incorrect_string_city", uniform_incorrect_string_data)
+def test_incorrect_uniform_city(incorrect_string_city):
+    with pytest.raises(Exception):
+        create_customer(city = incorrect_string_city)
+
+@pytest.mark.parametrize("incorrect_string_pesel", uniform_incorrect_string_data)
+def test_incorrect_uniform_pesel(incorrect_string_pesel):
+    with pytest.raises(Exception):
+        create_customer(pesel = incorrect_string_pesel)
+
+@pytest.mark.parametrize("incorrect_string_street", uniform_incorrect_string_data)
+def test_incorrect_uniform_street(incorrect_string_street):
+    with pytest.raises(Exception):
+        create_customer(street = incorrect_string_street)
+
+@pytest.mark.parametrize("incorrect_string_app", uniform_incorrect_string_data)
+def test_incorrect_uniform_app(incorrect_string_app):
+    with pytest.raises(Exception):
+        create_customer(name = incorrect_string_app)
+
+# Incorrect data for each case individually
+@pytest.mark.parametrize("incorrect_name",
+    [
+        None, 
+        "",
+        "123",
+        "A" * 65
+    ])
+def test_incorrect_name(incorrect_name):
+    with pytest.raises(Exception):
+        create_customer(name = incorrect_name)
+
+@pytest.mark.parametrize("incorrect_city",
+    [
+        "123",
+        "A" * 65
+    ])
+def test_incorrect_city(incorrect_city):
+    with pytest.raises(Exception):
+        create_customer(city = incorrect_city)
+
+@pytest.mark.parametrize("incorrect_age",
+    [
+        0,
+        -1,
+        -123,
+        1000,
+        12.4,
+        (),
+        [],
+        {},
+        "abc",
+        "17" 
+    ])
+def test_incorrect_age(incorrect_age):
+    with pytest.raises(Exception):
+        create_customer(city = incorrect_age)
+
+@pytest.mark.parametrize("incorrect_pesel",
+    [
+        "",
+        "1",
+        "1"*65,
+        "1"*10,
+        "1"*12,
+        "A"*11,
+    ])
+def test_incorrect_pesel(incorrect_pesel):
+    with pytest.raises(Exception):
+        create_customer(city = incorrect_pesel)
+
+@pytest.mark.parametrize("incorrect_street",
+    [
+        "123",
+        "asdad17",
+        "A"*129
+    ])
+def test_incorrect_street(incorrect_street):
+    with pytest.raises(Exception):
+        create_customer(city = incorrect_street)
+
+@pytest.mark.parametrize("incorrect_app",
+    [
+        "",
+        "bd123",
+        "aaaaa",
+        "A"*11
+    ])
+def test_incorrect_app(incorrect_app):
+    with pytest.raises(Exception):
+        create_customer(city = incorrect_app)

--- a/Python/Flask_Book_Library/tests/test_customer_injection.py
+++ b/Python/Flask_Book_Library/tests/test_customer_injection.py
@@ -1,0 +1,93 @@
+import pytest
+from project.customers.models import Customer
+
+SQL_Injections = [
+    "1' ORDER BY 1--+",
+    "1' ORDER BY 1,2--+",
+    "' OR 'x'='x",
+    "' AND id IS NULL; --"
+    "AND 0",
+    "AND true",
+    "-1 UNION SELECT 1 INTO @,@"
+]
+
+XSS_Injections = [
+    '"-prompt(8)-"',
+    "'-prompt(8)-'",
+    ";a=prompt,a()//",
+    "';a=prompt,a()//",
+    '"onclick=prompt(8)>"@x.y',
+    '"onclick=prompt(8)><svg/onload=prompt(8)>"@x.y',
+    "<image/src/onerror=prompt(8)>",
+    "<img/src/onerror=prompt(8)>",
+    "<image src/onerror=prompt(8)>",
+    "<img src/onerror=prompt(8)>"
+]
+
+def create_customer(name: str = "John Brown",
+                    city: str = "New York",
+                    age: int = 33,
+                    pesel: str = 11*"9",
+                    street: str = "Best Brooker",
+                    app: str = "17b") -> Customer:
+    Customer(name, city, age, pesel, street, app)
+    
+@pytest.mark.parametrize("incorrect_name", SQL_Injections)
+def test_sql_inject_name(incorrect_name):
+    with pytest.raises(Exception):
+        create_customer(name = incorrect_name)
+        
+@pytest.mark.parametrize("incorrect_name", XSS_Injections)
+def test_xss_inject_name(incorrect_name):
+    with pytest.raises(Exception):
+        create_customer(name = incorrect_name)
+        
+@pytest.mark.parametrize("incorrect_city", SQL_Injections)
+def test_sql_inject_city(incorrect_city):
+    with pytest.raises(Exception):
+        create_customer(city = incorrect_city)
+        
+@pytest.mark.parametrize("incorrect_city", XSS_Injections)
+def test_xss_inject_city(incorrect_city):
+    with pytest.raises(Exception):
+        create_customer(city = incorrect_city)
+        
+@pytest.mark.parametrize("incorrect_age", SQL_Injections)
+def test_sql_inject_age(incorrect_age):
+    with pytest.raises(Exception):
+        create_customer(age = incorrect_age)
+        
+@pytest.mark.parametrize("incorrect_age", XSS_Injections)
+def test_xss_inject_age(incorrect_age):
+    with pytest.raises(Exception):
+        create_customer(age = incorrect_age)
+        
+@pytest.mark.parametrize("incorrect_pesel", SQL_Injections)
+def test_sql_inject_pesel(incorrect_pesel):
+    with pytest.raises(Exception):
+        create_customer(pesel = incorrect_pesel)
+        
+@pytest.mark.parametrize("incorrect_pesel", XSS_Injections)
+def test_xss_inject_pesel(incorrect_pesel):
+    with pytest.raises(Exception):
+        create_customer(pesel = incorrect_pesel)
+
+@pytest.mark.parametrize("incorrect_street", SQL_Injections)
+def test_sql_inject_street(incorrect_street):
+    with pytest.raises(Exception):
+        create_customer(street = incorrect_street)
+        
+@pytest.mark.parametrize("incorrect_street", XSS_Injections)
+def test_xss_inject_street(incorrect_street):
+    with pytest.raises(Exception):
+        create_customer(street = incorrect_street)
+        
+@pytest.mark.parametrize("incorrect_app", SQL_Injections)
+def test_sql_inject_app(incorrect_app):
+    with pytest.raises(Exception):
+        create_customer(app = incorrect_app)
+        
+@pytest.mark.parametrize("incorrect_app", XSS_Injections)
+def test_xss_inject_app(incorrect_app):
+    with pytest.raises(Exception):
+        create_customer(app = incorrect_app)


### PR DESCRIPTION
# Zadanie 1
## Testy
Testy zostało zaimplementowane z wykorzystaniem dobrych praktyk integracyjnych na stronie dokumentacji [pytest.](https://docs.pytest.org/en/7.1.x/explanation/goodpractices.html)

W ramach zadania zostały utworzone testy dla modelu `Customer`. Testy znajdują się w folderze(`tests`) z testami dla każdego z 4 przypadków:
- testy poprawnych danych -> `test_customer_correct_data.py`
- testy niepoprawnych danych -> `test_customer_incorrect_data.py`
- testy powiązane z wstrzyknięciem kodu `SQL` lub `JavaScript` -> `test_customer_injection.py`
- testy ekstremalne-> `test_customer_extreme_data.py`

W przypadku wstrzyknięć `SQL` oraz `JavaScript` zostały wykorzystane przykłady z następujących stron:
- https://github.com/payloadbox/sql-injection-payload-list 
- https://github.com/payloadbox/xss-payload-list

## Dockerfile
Do pliku `Dockerfile` została dodana linijka `RUN python3 - m pytest`.

# Zadanie 2
## Wykonanie ataku JWT
### Oryginalny wygenerowany token:
```
"jwt":"eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJhY2NvdW50IjoiQm9iIiwicm9sZSI6IlVzZXIiLCJpYXQiOjE3MDIyMzMyMDEsImF1ZCI6Imh0dHBzOi8vMTI3LjAuMC4xL2p3dC9ub25lIn0.qzsN-hYk-WBjcHfT6dPhD4cmVD3GYH8WPAjJYeb18kU"
![obraz](https://github.com/The0Jan/task3/assets/73556824/07052190-dc32-48e3-bd62-3e8356f7d455)
```

### Utworzenie requesta o nazwie `none-send-token`

### Odpowiedź API dla oryginalnego tokenu:
![obraz](https://github.com/The0Jan/task3/assets/73556824/4252581a-6cd1-43b1-9c25-18f1d06d6024)


```
{
    "message": "Congrats!! You've solved the JWT challenge!!",
    "jwt_token": {
        "header": {
            "alg": "HS256",
            "typ": "JWT"
        },
        "payload": {
            "account": "Bob",
            "role": "User",
            "iat": 1702233201,
            "aud": "https://127.0.0.1/jwt/none"
        },
        "signature": "qzsN-hYk-WBjcHfT6dPhD4cmVD3GYH8WPAjJYeb18kU"
    }
}
```
### Zmiana wartości "account" na `"Administrator"` w tokenie

![obraz](https://github.com/The0Jan/task3/assets/73556824/d69a6b18-0f32-4736-af64-d489d07ba906)

### Zmiana 'header' w tokenie by "alg" był `"none"`
![obraz](https://github.com/The0Jan/task3/assets/73556824/06ede801-847c-4884-ba1c-78765b21ff3b)

W ramach ostatniej modyfikacji tokenu zostaną usunięte informacje na temat podpisu.

### Efekt końcowego zapytania z podrobionym tokenem 
![obraz](https://github.com/The0Jan/task3/assets/73556824/8184bb81-ae4f-4401-9ec5-2b422c306fed)


Podrobiony token:
```
eyJhbGciOiJub25lIiwidHlwIjoiSldUIn0.eyJhY2NvdW50IjoiQWRtaW5pc3RyYXRvciIsInJvbGUiOiJVc2VyIiwiaWF0IjoxNzAyMjMzMjAxLCJhdWQiOiJodHRwczovLzEyNy4wLjAuMS9qd3Qvbm9uZSJ9.
```

## Przygotowana poprawka
Po wprowadzeniu poprawki wynik zapytania z wykorzystaniem podobnie podrobionego tokenu wygląda następująco:
![obraz](https://github.com/The0Jan/task3/assets/73556824/70d49409-8ecb-4007-8626-aea4533aefb7)

